### PR TITLE
* add agent detection in gym env

### DIFF
--- a/core/env.py
+++ b/core/env.py
@@ -94,8 +94,11 @@ class GymEnv(Env):  # low dimensional observations
         self.logger.warning("State  Space: %s", self.state_shape)
 
         # continuous space
-        self.enable_continuous = args.enable_continuous
-    
+        if args.agent_type == "a3c":
+            self.enable_continuous = args.enable_continuous
+        else:
+            self.enable_continuous = False
+
     def _preprocessState(self, state):    # NOTE: here no preprecessing is needed
         return state
 


### PR DESCRIPTION
Otherwise, config 1 will give an error.
Cause there is an enable_continuous detection in step(), GymEnv object should always have an enable_continuous attribute. But in options.py, this is an attribute of a3c agent.